### PR TITLE
Timer revision

### DIFF
--- a/Game.cpp
+++ b/Game.cpp
@@ -518,6 +518,8 @@ void Game::applyGravity()
             if(locked) {
                 // lock delay has been spent, place the shape.
                 placeShape();
+                // placeShape can change the gameState if it was unable to place the new shape.
+                if(gameState == GameState::GAME_OVER) return;
             }
             else
             {

--- a/Game.h
+++ b/Game.h
@@ -109,7 +109,7 @@ private:
         }
     }
     bool locked;
-    void lockPiece() { time = 500; locked = true; }
+    static auto constexpr LOCK_DELAY = 500; // half a second
     // delay to next fall, in ms.
     double dropDelay() const {
         return

--- a/Game.h
+++ b/Game.h
@@ -92,8 +92,6 @@ private:
     void prepareScene(Color={255 / 3, 255 / 3, 255 / 3});
     void presentScene();
     // control logic (game.cpp)
-    // time (ms) game waits between renders. Also the value of 1G.
-    constexpr static uint32_t DELAY = 16;
     // timer logic
     int level;
     static constexpr int8_t LEVEL_CLEAR = 4;
@@ -115,7 +113,7 @@ private:
     // delay to next fall, in ms.
     double dropDelay() const {
         return
-            fastFall ? DELAY // fastfall speed
+            fastFall ? 1000/30.0 // fastfall is at 30 frames per second.
             : pow(0.8-(level-1)*0.007,level-1)*1000; // standard speed
     };
     // fall logic


### PR DESCRIPTION
So I did some testing, and the delay from rendering is not only non-trivial but it's often _larger_ than the delay we were manually waiting. This means that the game was running at at best half the speed it was supposed to. Considering the extra time incurred by the arduino, I'm sure the delay was even longer.

As such, I have removed it.

Also contained is a fix to piece locking; the timer should only have been reset while the piece was locked, but instead it's always reset.